### PR TITLE
Add char as an atomic value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.calva
+.clj-kondo
+.lsp

--- a/src/com/brunobonacci/rdt.clj
+++ b/src/com/brunobonacci/rdt.clj
@@ -55,13 +55,9 @@
 
 
 (defn- atomic-value?
+  "Returns true if `value` is atomic, false otherwise."
   [value]
-  (or (nil? value)
-    (boolean? value)
-    (number? value)
-    (keyword? value)
-    (string? value)
-    (symbol? value)))
+  (some #(% value) [nil? boolean? number? keyword? string? symbol? char?]))
 
 
 

--- a/test/com/brunobonacci/rdt_test.clj
+++ b/test/com/brunobonacci/rdt_test.clj
@@ -16,6 +16,7 @@
   (subset-matcher "foo" "foo") ==> true
   (subset-matcher nil nil) ==> true
   (subset-matcher 'foo 'foo) ==> true
+  (subset-matcher \c \c) ==> true
 
   (subset-matcher [] []) ==> true
   (subset-matcher [1] [1]) ==> true


### PR DESCRIPTION
Adding `char` as a subset value in the `subset-matcher`.

Test error output before:
```
FAIL REPL tests at (rdt_test.clj:19)
Expected:
true
Actual:
clojure.lang.ExceptionInfo: Unable to match pattern <\c> to value <\c>.

	Expected:
	  \c

	Found:
	  \c
```
