### PR TITLE
Adding support for primitive arrays in fuzzy matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.calva
+.clj-kondo
+.lsp

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The fuzzy match work as follow:
   )
 ```
 
-#### Lists and Vectors are matched on the given prefix
+#### Lists, Vectors and Primitive arrays are matched on the given prefix
 
 ``` clojure
 (repl-test
@@ -219,6 +219,12 @@ The fuzzy match work as follow:
   (list 2)       => '(1)  ;; false, test fails
   (list 1 2)     => '(1 3);; false, test fails, (1 3) is not a prefix of (1 2)
   (list 1 2 3)   => '(1 2);; true, (1 2) is a prefix of (1 2 3)
+
+  (byte-array 0)       => []    ;; true
+  (byte-array [1])     => [1]   ;; true
+  (byte-array [2])     => [1]   ;; false, test fails
+  (byte-array [1 2])   => [1 3] ;; false, test fails, [1 3] is not a prefix of [1 2]
+  (byte-array [1 2 3]) => [1 2] ;; true, [1 2] is a prefix of [1 2 3]
 )
 ```
 

--- a/src/com/brunobonacci/rdt.clj
+++ b/src/com/brunobonacci/rdt.clj
@@ -54,6 +54,24 @@
 
 
 
+(def primitive-arrays #{(Class/forName "[B") ;; bytes
+                        (Class/forName "[S") ;; shorts
+                        (Class/forName "[I") ;; ints
+                        (Class/forName "[J") ;; longs
+                        (Class/forName "[F") ;; floats
+                        (Class/forName "[D") ;; doubles
+                        (Class/forName "[C") ;; chars
+                        (Class/forName "[Z") ;; booleans
+                        (Class/forName "[Ljava.lang.Object;") ;; objects
+                        })
+
+(defn primitive-array?
+  "Returns true if x is a primitive array."
+  [x]
+  (-> (primitive-arrays (type x)) boolean))
+
+
+
 (defn- atomic-value?
   "Returns true if `value` is atomic, false otherwise."
   [value]
@@ -112,6 +130,9 @@
      (and (atomic-value? pattern) (atomic-value? value))
      (or (= pattern value)
        (match-error rpattern rvalue ppattern pvalue pattern value))
+
+     (and (sequential? pattern) (primitive-array? value))
+     (subset-matcher rpattern rvalue ppattern pvalue pattern (into [] value))
 
      (and (sequential? pattern) (sequential? value))
      (->> (zip-lists :rdt/<missing-value> pattern value)

--- a/src/com/brunobonacci/rdt.clj
+++ b/src/com/brunobonacci/rdt.clj
@@ -55,13 +55,9 @@
 
 
 (defn- atomic-value?
+  "Returns true if `value` is atomic, false otherwise."
   [value]
-  (or (nil? value)
-    (boolean? value)
-    (number? value)
-    (keyword? value)
-    (string? value)
-    (symbol? value)))
+  (some #(% value) [nil? boolean? number? keyword? string? symbol? char?]))
 
 
 

--- a/src/com/brunobonacci/rdt.clj
+++ b/src/com/brunobonacci/rdt.clj
@@ -68,7 +68,7 @@
 (defn primitive-array?
   "Returns true if x is a primitive array."
   [x]
-  (-> (primitive-arrays (type x)) boolean))
+  (-> x type primitive-arrays boolean))
 
 
 

--- a/test/com/brunobonacci/rdt_test.clj
+++ b/test/com/brunobonacci/rdt_test.clj
@@ -43,6 +43,71 @@
   (subset-matcher #{1 2} #{1 2 3 4}) ==> true
   (subset-matcher #{1 2 3 4} #{1 2}) ==> (throws Exception)
 
+  (subset-matcher [] (byte-array [])) ==> true
+  (subset-matcher [1] (byte-array [1])) ==> true
+  (subset-matcher [2] (byte-array [1])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (byte-array [1 2 3])) ==> true
+  (subset-matcher [1 2 3] (byte-array [1 2 3 4])) ==> true
+  (subset-matcher [1 2 3 4] (byte-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (short-array [])) ==> true
+  (subset-matcher [1] (short-array [1])) ==> true
+  (subset-matcher [2] (short-array [1])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (short-array [1 2 3])) ==> true
+  (subset-matcher [1 2 3] (short-array [1 2 3 4])) ==> true
+  (subset-matcher [1 2 3 4] (short-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (int-array [])) ==> true
+  (subset-matcher [1] (int-array [1])) ==> true
+  (subset-matcher [2] (int-array [1])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (int-array [1 2 3])) ==> true
+  (subset-matcher [1 2 3] (int-array [1 2 3 4])) ==> true
+  (subset-matcher [1 2 3 4] (int-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (long-array [])) ==> true
+  (subset-matcher [1] (long-array [1])) ==> true
+  (subset-matcher [2] (long-array [1])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (long-array [1 2 3])) ==> true
+  (subset-matcher [1 2 3] (long-array [1 2 3 4])) ==> true
+  (subset-matcher [1 2 3 4] (long-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (float-array [])) ==> true
+  (subset-matcher [1.0] (float-array [1])) ==> true
+  (subset-matcher [2.0] (float-array [1])) ==> (throws Exception)
+  (subset-matcher [1.0 2.0 3.0] (float-array [1 2 3])) ==> true
+  (subset-matcher [1.0 2.0 3.0] (float-array [1 2 3 4])) ==> true
+  (subset-matcher [1.0 2.0 3.0 4.0] (float-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (double-array [])) ==> true
+  (subset-matcher [1.0] (double-array [1])) ==> true
+  (subset-matcher [2.0] (double-array [1])) ==> (throws Exception)
+  (subset-matcher [1.0 2.0 3.0] (double-array [1 2 3])) ==> true
+  (subset-matcher [1.0 2.0 3.0] (double-array [1 2 3 4])) ==> true
+  (subset-matcher [1.0 2.0 3.0 4.0] (double-array [1 2 3])) ==> (throws Exception)
+
+  (subset-matcher [] (char-array [])) ==> true
+  (subset-matcher [\a] (char-array [\a])) ==> true
+  (subset-matcher [\b] (char-array [\a])) ==> (throws Exception)
+  (subset-matcher [\a \b \c] (char-array [\a \b \c])) ==> true
+  (subset-matcher [\a \b \c] (char-array [\a \b \c \d])) ==> true
+  (subset-matcher [\a \b \c \d] (char-array [\a \b \c])) ==> (throws Exception)
+
+  (subset-matcher [] (boolean-array [])) ==> true
+  (subset-matcher [true] (boolean-array [true])) ==> true
+  (subset-matcher [false] (boolean-array [true])) ==> (throws Exception)
+  (subset-matcher [true false] (boolean-array [true false])) ==> true
+  (subset-matcher
+    [true false true false]
+    (boolean-array [true false true])) ==> (throws Exception)
+
+  (subset-matcher [] (object-array [])) ==> true
+  (subset-matcher [1] (object-array [1])) ==> true
+  (subset-matcher [2] (object-array [1])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (object-array [1 2 3])) ==> true
+  (subset-matcher [1 2 3] (object-array [1 2 :x])) ==> (throws Exception)
+  (subset-matcher [1 2 3] (object-array [1 2 3 4])) ==> true
+  (subset-matcher [1 2 3 4] (object-array [1 2 3])) ==> (throws Exception)
+
   (subset-matcher {:s 2} {:s 2}) ==> true
   (subset-matcher {:s 2 :b 3} {:s 2 :b 3}) ==> true
   (subset-matcher {:s 2 :b 3} {:s 2 :b 3 :x 4}) ==> true

--- a/test/com/brunobonacci/rdt_test.clj
+++ b/test/com/brunobonacci/rdt_test.clj
@@ -16,6 +16,7 @@
   (subset-matcher "foo" "foo") ==> true
   (subset-matcher nil nil) ==> true
   (subset-matcher 'foo 'foo) ==> true
+  (subset-matcher \c \c) ==> true
 
   (subset-matcher [] []) ==> true
   (subset-matcher [1] [1]) ==> true


### PR DESCRIPTION
This will need #3 to be merged first.

adds support for primitive arrays in the fuzzy matcher