### PR TITLE
Add number equivalent value check

### DIFF
--- a/src/com/brunobonacci/rdt.clj
+++ b/src/com/brunobonacci/rdt.clj
@@ -129,6 +129,7 @@
    (cond
      (and (atomic-value? pattern) (atomic-value? value))
      (or (= pattern value)
+       (and (number? pattern) (number? value) (== pattern value))
        (match-error rpattern rvalue ppattern pvalue pattern value))
 
      (and (sequential? pattern) (primitive-array? value))

--- a/test/com/brunobonacci/rdt_test.clj
+++ b/test/com/brunobonacci/rdt_test.clj
@@ -17,6 +17,8 @@
   (subset-matcher nil nil) ==> true
   (subset-matcher 'foo 'foo) ==> true
   (subset-matcher \c \c) ==> true
+  (subset-matcher 1.0 1) ==> true
+  (subset-matcher 1 1.0) ==> true
 
   (subset-matcher [] []) ==> true
   (subset-matcher [1] [1]) ==> true


### PR DESCRIPTION
Added number equivalent check within fuzzy matcher.

Before:
```clojure
(repl-test "Number equivalent check?"
  1.0 => 1
  1   => 1.0)
```

outputs
```
Actual result:
1.0
Checking function: (com.brunobonacci.rdt/fuzzy-checker 1)
    The checker said this about the reason:
        Unable to match pattern <1> to value <1.0>.

	Expected:
	  1

	Found:
	  1.0
	  
Actual result:
1
Checking function: (com.brunobonacci.rdt/fuzzy-checker 1.0)
    The checker said this about the reason:
        Unable to match pattern <1.0> to value <1>.

	Expected:
	  1.0

	Found:
	  1
```